### PR TITLE
feat: add themed layout with dark mode toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,26 +1,8 @@
 @import "tailwindcss";
 
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-}
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
-
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+@layer base {
+  body {
+    @apply bg-background-light text-foreground-light dark:bg-background-dark dark:text-foreground-dark;
+    font-family: Arial, Helvetica, sans-serif;
   }
-}
-
-body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,8 +1,227 @@
-@import "tailwindcss";
+/* -------- Color System -------- */
+:root {
+  --bg: #f6f6f6;
+  --fg: #000000;
+  --accent: #cfffe2;
+  --muted: #a2d5c6;
 
-@layer base {
-  body {
-    @apply bg-background text-foreground dark:bg-background-dark dark:text-foreground-dark;
-    font-family: Arial, Helvetica, sans-serif;
+  --radius: 14px;
+  --shadow-soft: 0 8px 24px rgba(0, 0, 0, 0.06);
+  --shadow-card: 0 4px 16px rgba(0, 0, 0, 0.08);
+}
+
+.dark {
+  --bg: #000000;
+  --fg: #f6f6f6;
+  /* keep accents consistent across themes */
+  --accent: #cfffe2;
+  --muted: #a2d5c6;
+
+  --shadow-soft: 0 8px 24px rgba(255, 255, 255, 0.06);
+  --shadow-card: 0 4px 16px rgba(255, 255, 255, 0.08);
+}
+
+/* -------- Base -------- */
+* {
+  box-sizing: border-box;
+}
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--fg);
+  font-family: var(--font-geist-sans), system-ui, -apple-system, Segoe UI,
+    Roboto, Inter, Arial, sans-serif;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+}
+
+img,
+svg {
+  display: block;
+  max-width: 100%;
+}
+a {
+  color: inherit;
+  text-decoration: none;
+}
+a:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 8px;
+}
+
+.container {
+  width: min(1100px, 100%);
+  margin-inline: auto;
+  padding-inline: 24px;
+}
+
+/* -------- Header / Nav -------- */
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: var(--bg);
+  border-bottom: 1px solid color-mix(in srgb, var(--fg) 10%, transparent);
+  backdrop-filter: blur(8px);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 0;
+}
+
+.brand {
+  font-weight: 800;
+  letter-spacing: 0.2px;
+  font-size: 1.125rem;
+}
+
+.nav-list {
+  display: flex;
+  gap: 24px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-link {
+  position: relative;
+  padding: 6px 4px;
+  transition: color 180ms ease;
+}
+.nav-link::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: -2px;
+  height: 2px;
+  background: var(--accent);
+  transform: scaleX(0);
+  transform-origin: left;
+  transition: transform 220ms ease;
+  border-radius: 1px;
+}
+.nav-link:hover::after,
+.nav-link[aria-current="page"]::after {
+  transform: scaleX(1);
+}
+.nav-link:hover {
+  color: var(--fg);
+}
+
+/* -------- Buttons -------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 12px 20px;
+  border-radius: var(--radius);
+  border: 1px solid transparent;
+  font-weight: 600;
+  line-height: 1;
+  transition: transform 120ms ease, background-color 160ms ease,
+    border-color 160ms ease, opacity 160ms ease;
+  will-change: transform;
+}
+.btn:active {
+  transform: translateY(1px);
+}
+
+.btn-primary {
+  background: var(--accent);
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--fg) 15%, transparent);
+}
+.btn-primary:hover {
+  opacity: 0.92;
+}
+
+.btn-outline {
+  background: transparent;
+  color: var(--fg);
+  border-color: color-mix(in srgb, var(--fg) 35%, transparent);
+}
+.btn-outline:hover {
+  background: color-mix(in srgb, var(--muted) 30%, transparent);
+}
+
+/* -------- Hero -------- */
+.hero {
+  display: grid;
+  place-items: center;
+  text-align: center;
+  gap: 20px;
+  padding-block: clamp(72px, 10vw, 120px);
+  animation: fadeIn 0.6s ease-out both;
+}
+.hero h1 {
+  font-size: clamp(2.2rem, 4.5vw, 3.5rem);
+  line-height: 1.1;
+  margin: 0;
+  letter-spacing: -0.5px;
+}
+.hero p {
+  margin: 0 auto;
+  max-width: 42ch;
+  opacity: 0.85;
+  font-size: clamp(1rem, 1.2vw, 1.125rem);
+}
+.highlight {
+  color: var(--accent);
+}
+
+/* -------- Footer -------- */
+.footer {
+  border-top: 1px solid color-mix(in srgb, var(--fg) 10%, transparent);
+  padding: 28px 0;
+  text-align: center;
+  margin-top: 72px;
+}
+.footer-links {
+  display: flex;
+  justify-content: center;
+  gap: 18px;
+  margin-top: 8px;
+}
+.footer a {
+  opacity: 0.9;
+}
+.footer a:hover {
+  opacity: 1;
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* -------- Utilities -------- */
+.fade-in {
+  animation: fadeIn 0.6s ease-out both;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* -------- Small screens -------- */
+@media (max-width: 720px) {
+  .nav {
+    gap: 10px;
+  }
+  .nav-list {
+    gap: 14px;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,7 +2,7 @@
 
 @layer base {
   body {
-    @apply bg-background-light text-foreground-light dark:bg-background-dark dark:text-foreground-dark;
+    @apply bg-background text-foreground dark:bg-background-dark dark:text-foreground-dark;
     font-family: Arial, Helvetica, sans-serif;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import Link from "next/link";
+import ThemeToggle from "@/components/ThemeToggle";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -24,44 +26,36 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[#F6F6F6] text-[#000000]`}
-      >
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         {/* Navbar */}
-        <header className="bg-[#F6F6F6] shadow-md">
+        <header className="bg-background-light dark:bg-background-dark shadow-md">
           <nav className="max-w-5xl mx-auto flex justify-between items-center py-4 px-6">
             <h1 className="text-xl font-bold">MyPortfolio</h1>
-            <ul className="flex space-x-6">
-              <li>
-                <a href="/" className="hover:text-[#CFFFE2] transition-colors">
-                  Home
-                </a>
-              </li>
-              <li>
-                <a
-                  href="/projects"
-                  className="hover:text-[#CFFFE2] transition-colors"
-                >
-                  Projects
-                </a>
-              </li>
-              <li>
-                <a
-                  href="/blog"
-                  className="hover:text-[#CFFFE2] transition-colors"
-                >
-                  Blog
-                </a>
-              </li>
-              <li>
-                <a
-                  href="/contact"
-                  className="hover:text-[#CFFFE2] transition-colors"
-                >
-                  Contact
-                </a>
-              </li>
-            </ul>
+            <div className="flex items-center space-x-6">
+              <ul className="flex space-x-6">
+                <li>
+                  <Link href="/" className="hover:text-accent transition-colors">
+                    Home
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/projects" className="hover:text-accent transition-colors">
+                    Projects
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/blog" className="hover:text-accent transition-colors">
+                    Blog
+                  </Link>
+                </li>
+                <li>
+                  <Link href="/contact" className="hover:text-accent transition-colors">
+                    Contact
+                  </Link>
+                </li>
+              </ul>
+              <ThemeToggle />
+            </div>
           </nav>
         </header>
 
@@ -69,7 +63,7 @@ export default function RootLayout({
         <main className="max-w-5xl mx-auto px-6 py-8">{children}</main>
 
         {/* Footer */}
-        <footer className="bg-[#A2D5C6] text-center py-6 mt-12">
+        <footer className="bg-muted text-center py-6 mt-12 text-foreground-light dark:text-foreground-dark">
           <p className="text-sm">
             © {new Date().getFullYear()} My Name. Built with Next.js.
           </p>
@@ -78,7 +72,7 @@ export default function RootLayout({
               href="https://github.com/yourusername"
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-[#CFFFE2] transition-colors"
+              className="hover:text-accent transition-colors"
             >
               GitHub
             </a>
@@ -86,7 +80,7 @@ export default function RootLayout({
               href="https://linkedin.com/in/yourusername"
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-[#CFFFE2] transition-colors"
+              className="hover:text-accent transition-colors"
             >
               LinkedIn
             </a>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,7 +8,6 @@ const geistSans = Geist({
   variable: "--font-geist-sans",
   subsets: ["latin"],
 });
-
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
@@ -21,72 +20,73 @@ export const metadata: Metadata = {
 
 export default function RootLayout({
   children,
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+}: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={`${geistSans.variable} ${geistMono.variable}`}>
         {/* Navbar */}
-        <header className="sticky top-0 z-50 bg-background dark:bg-background-dark border-b border-muted">
-          <nav className="max-w-5xl mx-auto flex justify-between items-center py-4 px-6">
-            <Link href="/" className="text-xl font-bold">
+        <header className="header">
+          <div className="container nav">
+            <Link href="/" className="brand" aria-label="Go to home">
               MyPortfolio
             </Link>
-            <div className="flex items-center space-x-6">
-              <ul className="flex space-x-6">
+
+            <nav aria-label="Primary">
+              <ul className="nav-list">
                 <li>
-                  <Link href="/" className="hover:text-accent transition-colors">
+                  <Link href="/" className="nav-link">
                     Home
                   </Link>
                 </li>
                 <li>
-                  <Link href="/projects" className="hover:text-accent transition-colors">
+                  <Link href="/projects" className="nav-link">
                     Projects
                   </Link>
                 </li>
                 <li>
-                  <Link href="/blog" className="hover:text-accent transition-colors">
+                  <Link href="/blog" className="nav-link">
                     Blog
                   </Link>
                 </li>
                 <li>
-                  <Link href="/contact" className="hover:text-accent transition-colors">
+                  <Link href="/contact" className="nav-link">
                     Contact
                   </Link>
                 </li>
               </ul>
-              <ThemeToggle />
-            </div>
-          </nav>
+            </nav>
+
+            <ThemeToggle />
+          </div>
         </header>
 
-        {/* Main Content */}
-        <main className="max-w-5xl mx-auto px-6 py-8">{children}</main>
+        {/* Main */}
+        <main className="container" style={{ paddingBlock: "32px" }}>
+          {children}
+        </main>
 
         {/* Footer */}
-        <footer className="bg-background dark:bg-background-dark border-t border-muted text-center py-6 mt-12">
-          <p className="text-sm text-foreground dark:text-foreground-dark">
-            © {new Date().getFullYear()} My Name. Built with Next.js.
-          </p>
-          <div className="mt-2 flex justify-center space-x-4">
-            <a
-              href="https://github.com/yourusername"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-accent transition-colors"
-            >
-              GitHub
-            </a>
-            <a
-              href="https://linkedin.com/in/yourusername"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="hover:text-accent transition-colors"
-            >
-              LinkedIn
-            </a>
+        <footer className="footer">
+          <div className="container">
+            <p style={{ margin: 0 }}>
+              © {new Date().getFullYear()} My Name — Built with Next.js.
+            </p>
+            <div className="footer-links">
+              <a
+                href="https://github.com/yourusername"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                GitHub
+              </a>
+              <a
+                href="https://linkedin.com/in/yourusername"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                LinkedIn
+              </a>
+            </div>
           </div>
         </footer>
       </body>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,11 +26,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+      >
         {/* Navbar */}
-        <header className="bg-background-light dark:bg-background-dark shadow-md">
+        <header className="sticky top-0 z-50 bg-background dark:bg-background-dark border-b border-muted">
           <nav className="max-w-5xl mx-auto flex justify-between items-center py-4 px-6">
-            <h1 className="text-xl font-bold">MyPortfolio</h1>
+            <Link href="/" className="text-xl font-bold">
+              MyPortfolio
+            </Link>
             <div className="flex items-center space-x-6">
               <ul className="flex space-x-6">
                 <li>
@@ -63,8 +66,8 @@ export default function RootLayout({
         <main className="max-w-5xl mx-auto px-6 py-8">{children}</main>
 
         {/* Footer */}
-        <footer className="bg-muted text-center py-6 mt-12 text-foreground-light dark:text-foreground-dark">
-          <p className="text-sm">
+        <footer className="bg-background dark:bg-background-dark border-t border-muted text-center py-6 mt-12">
+          <p className="text-sm text-foreground dark:text-foreground-dark">
             © {new Date().getFullYear()} My Name. Built with Next.js.
           </p>
           <div className="mt-2 flex justify-center space-x-4">

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,103 +1,16 @@
-import Image from "next/image";
-
 export default function Home() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
-
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
-    </div>
+    <section className="text-center space-y-6">
+      <h2 className="text-4xl font-bold">Hi, I&apos;m Your Name</h2>
+      <p className="text-lg max-w-2xl mx-auto">
+        I&apos;m a full-stack developer focused on building modern web applications.
+      </p>
+      <a
+        href="/projects"
+        className="inline-block px-6 py-3 rounded bg-accent hover:bg-muted transition-colors text-foreground-light dark:text-foreground-dark"
+      >
+        View Projects
+      </a>
+    </section>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,28 +2,31 @@ import Link from "next/link";
 
 export default function Home() {
   return (
-    <section className="flex flex-col items-center justify-center gap-6 py-24 text-center animate-fadeIn">
-      <h1 className="text-5xl font-bold">
-        Hi, I&apos;m <span className="text-accent">Your Name</span>
+    <section className="hero fade-in">
+      <h1>
+        Hi, I&apos;m <span className="highlight">Your Name</span>
       </h1>
-      <p className="text-lg max-w-xl text-foreground/80 dark:text-foreground-dark/80">
-        I&apos;m a full-stack developer focused on building modern web applications.
+
+      <p>
+        I&apos;m a full-stack developer focused on building modern web
+        applications.
       </p>
-      <div className="flex gap-4">
-        <Link
-          href="/projects"
-          className="px-6 py-3 rounded-md bg-accent text-foreground hover:bg-muted transition-colors"
-        >
+
+      <div
+        style={{
+          display: "flex",
+          gap: 12,
+          justifyContent: "center",
+          marginTop: 10,
+        }}
+      >
+        <Link href="/projects" className="btn btn-primary">
           View Projects
         </Link>
-        <Link
-          href="/contact"
-          className="px-6 py-3 rounded-md border border-foreground dark:border-foreground-dark hover:bg-muted transition-colors"
-        >
+        <Link href="/contact" className="btn btn-outline">
           Contact Me
         </Link>
       </div>
     </section>
   );
 }
-

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,16 +1,29 @@
+import Link from "next/link";
+
 export default function Home() {
   return (
-    <section className="text-center space-y-6">
-      <h2 className="text-4xl font-bold">Hi, I&apos;m Your Name</h2>
-      <p className="text-lg max-w-2xl mx-auto">
+    <section className="flex flex-col items-center justify-center gap-6 py-24 text-center animate-fadeIn">
+      <h1 className="text-5xl font-bold">
+        Hi, I&apos;m <span className="text-accent">Your Name</span>
+      </h1>
+      <p className="text-lg max-w-xl text-foreground/80 dark:text-foreground-dark/80">
         I&apos;m a full-stack developer focused on building modern web applications.
       </p>
-      <a
-        href="/projects"
-        className="inline-block px-6 py-3 rounded bg-accent hover:bg-muted transition-colors text-foreground-light dark:text-foreground-dark"
-      >
-        View Projects
-      </a>
+      <div className="flex gap-4">
+        <Link
+          href="/projects"
+          className="px-6 py-3 rounded-md bg-accent text-foreground hover:bg-muted transition-colors"
+        >
+          View Projects
+        </Link>
+        <Link
+          href="/contact"
+          className="px-6 py-3 rounded-md border border-foreground dark:border-foreground-dark hover:bg-muted transition-colors"
+        >
+          Contact Me
+        </Link>
+      </div>
     </section>
   );
 }
+

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -3,14 +3,16 @@
 import { useEffect, useState } from "react";
 
 export default function ThemeToggle() {
-  const [theme, setTheme] = useState("light");
+  const [theme, setTheme] = useState<"light" | "dark">("light");
 
   useEffect(() => {
-    const stored = localStorage.getItem("theme");
-    if (stored === "dark") {
-      document.documentElement.classList.add("dark");
-      setTheme("dark");
-    }
+    const stored = localStorage.getItem("theme") as "light" | "dark" | null;
+    const prefersDark = window.matchMedia?.(
+      "(prefers-color-scheme: dark)"
+    ).matches;
+    const initial = stored ?? (prefersDark ? "dark" : "light");
+    setTheme(initial);
+    document.documentElement.classList.toggle("dark", initial === "dark");
   }, []);
 
   const toggle = () => {
@@ -23,8 +25,9 @@ export default function ThemeToggle() {
   return (
     <button
       onClick={toggle}
-      className="px-3 py-2 rounded bg-accent hover:bg-muted transition-colors text-foreground dark:text-foreground-dark"
+      className="btn btn-outline"
       aria-label="Toggle dark mode"
+      title="Toggle theme"
     >
       {theme === "light" ? "Dark" : "Light"} Mode
     </button>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -23,7 +23,7 @@ export default function ThemeToggle() {
   return (
     <button
       onClick={toggle}
-      className="px-3 py-2 rounded bg-accent hover:bg-muted transition-colors text-foreground-light dark:text-foreground-dark"
+      className="px-3 py-2 rounded bg-accent hover:bg-muted transition-colors text-foreground dark:text-foreground-dark"
       aria-label="Toggle dark mode"
     >
       {theme === "light" ? "Dark" : "Light"} Mode

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState("light");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    if (stored === "dark") {
+      document.documentElement.classList.add("dark");
+      setTheme("dark");
+    }
+  }, []);
+
+  const toggle = () => {
+    const next = theme === "light" ? "dark" : "light";
+    setTheme(next);
+    document.documentElement.classList.toggle("dark", next === "dark");
+    localStorage.setItem("theme", next);
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      className="px-3 py-2 rounded bg-accent hover:bg-muted transition-colors text-foreground-light dark:text-foreground-dark"
+      aria-label="Toggle dark mode"
+    >
+      {theme === "light" ? "Dark" : "Light"} Mode
+    </button>
+  );
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,15 +7,24 @@ const config: Config = {
     extend: {
       colors: {
         background: {
-          light: "#F6F6F6",
+          DEFAULT: "#F6F6F6",
           dark: "#000000",
         },
         foreground: {
-          light: "#000000",
+          DEFAULT: "#000000",
           dark: "#F6F6F6",
         },
         accent: "#CFFFE2",
         muted: "#A2D5C6",
+      },
+      keyframes: {
+        fadeIn: {
+          from: { opacity: "0", transform: "translateY(10px)" },
+          to: { opacity: "1", transform: "translateY(0)" },
+        },
+      },
+      animation: {
+        fadeIn: "fadeIn 0.6s ease-out forwards",
       },
     },
   },

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,25 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  darkMode: "class",
+  content: ["./src/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        background: {
+          light: "#F6F6F6",
+          dark: "#000000",
+        },
+        foreground: {
+          light: "#000000",
+          dark: "#F6F6F6",
+        },
+        accent: "#CFFFE2",
+        muted: "#A2D5C6",
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- configure Tailwind with custom portfolio color palette and class-based dark mode
- implement site layout using palette and add a ThemeToggle component
- create a simple portfolio home page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c67a7093f08328b8d8a34b8248616c